### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions-ecosystem/action-add-labels@v1
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/rubixkube-io/domino-effect-challenge/security/code-scanning/1](https://github.com/rubixkube-io/domino-effect-challenge/security/code-scanning/1)

To fix this issue, add an explicit `permissions:` block to the triage workflow. Since the only relevant operation is applying a label to a newly created issue, the minimal required permission is `issues: write`. This block should be added under the specific job (`label`), or at the workflow root if all jobs require the same permission. In this case, since there is only one job (`label`), we will add it directly under the job. No other code changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
